### PR TITLE
fix: history disable

### DIFF
--- a/src/core/HistoryHandler.ts
+++ b/src/core/HistoryHandler.ts
@@ -51,6 +51,11 @@ export class HistoryHandler extends EventTarget {
 
 	private initialize(event: InitEvent): void {
 		const {defaultOptions} = event.detail;
+		
+		if (!defaultOptions.history) {
+			return;
+		}
+		
 		window.addEventListener('popstate', this.popStateHandler);
 		onDomReady(() => this.historyAdapter.replaceState(
 			this.buildState(window.location.href, defaultOptions),


### PR DESCRIPTION
@jiripudil history is currently not fully disabled when `history: false` is set. This should fix it.

History in naja is not friendly with https://swup.js.org/ currently, that's the main reason we need this disabled.
That first replaceState on dom ready kind confuses swup. Because when you click back button in browser, swup thinks that page was not loaded with swup, so it does nothing and page is not loaded.

I am not sure of the reason why there has to be a replaceState on first load in the first load. Shouldn't this be only when naja request is made?