### PR TITLE
HistoryHandler: initialize on demand

### DIFF
--- a/src/core/HistoryHandler.ts
+++ b/src/core/HistoryHandler.ts
@@ -15,6 +15,7 @@ declare module '../Naja' {
 }
 
 export interface HistoryState extends Record<string, any> {
+	source: string;
 	href: string;
 }
 
@@ -53,7 +54,7 @@ export class HistoryHandler extends EventTarget {
 
 	private handlePopState(event: PopStateEvent): void {
 		const {state} = event;
-		if ( ! state) {
+		if (state?.source !== 'naja') {
 			return;
 		}
 
@@ -129,7 +130,7 @@ export class HistoryHandler extends EventTarget {
 	}
 
 	private buildState(href: string, options: Options): HistoryState {
-		const state: HistoryState = {href};
+		const state: HistoryState = {source: 'naja', href};
 		this.dispatchEvent(new CustomEvent('buildState', {detail: {state, options}}));
 		return state;
 	}

--- a/src/core/HistoryHandler.ts
+++ b/src/core/HistoryHandler.ts
@@ -5,6 +5,7 @@ import {onDomReady, TypedEventListener} from '../utils';
 declare module '../Naja' {
 	interface Options {
 		history?: HistoryMode;
+		href?: string;
 	}
 
 	interface Payload {
@@ -25,7 +26,6 @@ export interface HistoryAdapter {
 export type HistoryMode = boolean | 'replace';
 
 export class HistoryHandler extends EventTarget {
-	private href: string | null = null;
 	public popStateHandler = this.handlePopState.bind(this);
 	public historyAdapter: HistoryAdapter;
 
@@ -70,8 +70,8 @@ export class HistoryHandler extends EventTarget {
 	}
 
 	private saveUrl(event: BeforeEvent): void {
-		const {url} = event.detail;
-		this.href = url;
+		const {url, options} = event.detail;
+		options.href ??= url;
 	}
 
 	private configureMode(event: InteractionEvent): void {
@@ -107,17 +107,15 @@ export class HistoryHandler extends EventTarget {
 		}
 
 		if (payload.postGet && payload.url) {
-			this.href = payload.url;
+			options.href = payload.url;
 		}
 
 		const method = mode === 'replace' ? 'replaceState' : 'pushState';
 		this.historyAdapter[method](
-			this.buildState(this.href!, options),
+			this.buildState(options.href!, options),
 			window.document.title,
-			this.href!,
+			options.href!,
 		);
-
-		this.href = null;
 	}
 
 	private buildState(href: string, options: Options): HistoryState {

--- a/tests/Naja.HistoryHandler.js
+++ b/tests/Naja.HistoryHandler.js
@@ -13,6 +13,34 @@ import {UIHandler} from '../src/core/UIHandler';
 describe('HistoryHandler', function () {
 	fakeFetch();
 
+	it('is initialized when history-enabled request is dispatched', function () {
+		const naja = mockNaja({
+			historyHandler: HistoryHandler,
+		});
+
+		assert.isFalse(naja.historyHandler.initialized);
+
+		naja.addEventListener('before', (event) => event.preventDefault());
+
+		return naja.makeRequest('GET', '/HistoryHandler/initialize').then(() => {
+			assert.isTrue(naja.historyHandler.initialized);
+		});
+	});
+
+	it('is not initialized when non-history-enabled request is dispatched', function () {
+		const naja = mockNaja({
+			historyHandler: HistoryHandler,
+		});
+
+		assert.isFalse(naja.historyHandler.initialized);
+
+		naja.addEventListener('before', (event) => event.preventDefault());
+
+		return naja.makeRequest('GET', '/HistoryHandler/initialize', null, {history: false}).then(() => {
+			assert.isFalse(naja.historyHandler.initialized);
+		});
+	});
+
 	it('saves initial state', function () {
 		const naja = mockNaja();
 		const historyHandler = new HistoryHandler(naja);
@@ -20,8 +48,7 @@ describe('HistoryHandler', function () {
 		const mock = sinon.mock(historyHandler.historyAdapter);
 		mock.expects('replaceState').withExactArgs({href: 'http://localhost:9876/context.html'}, '', 'http://localhost:9876/context.html').once();
 
-		historyHandler.initialize(new CustomEvent('init', {detail: {defaultOptions: {}}}));
-		cleanPopstateListener(historyHandler);
+		historyHandler.replaceInitialState(new CustomEvent('before', {detail: {options: {history: true}}}));
 
 		mock.verify();
 		mock.restore();
@@ -32,8 +59,8 @@ describe('HistoryHandler', function () {
 			snippetHandler: SnippetHandler,
 			historyHandler: HistoryHandler,
 		});
-		naja.initialize();
-		cleanPopstateListener(naja.historyHandler);
+
+		naja.historyHandler.initialized = true;
 
 		const mock = sinon.mock(naja.historyHandler.historyAdapter);
 		mock.expects('pushState').withExactArgs({href: 'http://localhost:9876/HistoryHandler/pushState'}, '', 'http://localhost:9876/HistoryHandler/pushState').once();
@@ -50,8 +77,8 @@ describe('HistoryHandler', function () {
 			snippetHandler: SnippetHandler,
 			historyHandler: HistoryHandler,
 		});
-		naja.initialize();
-		cleanPopstateListener(naja.historyHandler);
+
+		naja.historyHandler.initialized = true;
 
 		const mock = sinon.mock(naja.historyHandler.historyAdapter);
 		mock.expects('replaceState').withExactArgs({href: 'http://localhost:9876/HistoryHandler/replaceState'}, '', 'http://localhost:9876/HistoryHandler/replaceState').once();
@@ -68,8 +95,8 @@ describe('HistoryHandler', function () {
 			snippetHandler: SnippetHandler,
 			historyHandler: HistoryHandler,
 		});
-		naja.initialize();
-		cleanPopstateListener(naja.historyHandler);
+
+		naja.historyHandler.initialized = true;
 
 		const mock = sinon.mock(naja.historyHandler.historyAdapter);
 		mock.expects('pushState').withExactArgs({href: '/HistoryHandler/postGet/targetUrl'}, '', '/HistoryHandler/postGet/targetUrl').once();
@@ -86,8 +113,6 @@ describe('HistoryHandler', function () {
 			snippetHandler: SnippetHandler,
 			historyHandler: HistoryHandler,
 		});
-		naja.initialize();
-		cleanPopstateListener(naja.historyHandler);
 
 		const mock = sinon.mock(naja.historyHandler.historyAdapter);
 		mock.expects('pushState').never();
@@ -196,8 +221,8 @@ describe('HistoryHandler', function () {
 				snippetHandler: SnippetHandler,
 				historyHandler: HistoryHandler,
 			});
-			naja.initialize();
-			cleanPopstateListener(naja.historyHandler);
+
+			naja.historyHandler.initialized = true;
 
 			const mock = sinon.mock(naja.historyHandler.historyAdapter);
 			mock.expects('pushState').once();
@@ -226,7 +251,7 @@ describe('HistoryHandler', function () {
 				snippetHandler: SnippetHandler,
 				historyHandler: HistoryHandler,
 			});
-			naja.initialize();
+			naja.historyHandler.initialize();
 
 			const restoreCallback = sinon.spy();
 			naja.historyHandler.addEventListener('restoreState', restoreCallback);
@@ -251,7 +276,7 @@ describe('HistoryHandler', function () {
 				snippetHandler: SnippetHandler,
 				historyHandler: HistoryHandler,
 			});
-			naja.initialize();
+			naja.historyHandler.initialize();
 
 			const restoreCallback = sinon.spy();
 			naja.historyHandler.addEventListener('restoreState', restoreCallback);

--- a/tests/Naja.HistoryHandler.js
+++ b/tests/Naja.HistoryHandler.js
@@ -46,7 +46,7 @@ describe('HistoryHandler', function () {
 		const historyHandler = new HistoryHandler(naja);
 
 		const mock = sinon.mock(historyHandler.historyAdapter);
-		mock.expects('replaceState').withExactArgs({href: 'http://localhost:9876/context.html'}, '', 'http://localhost:9876/context.html').once();
+		mock.expects('replaceState').withExactArgs({source: 'naja', href: 'http://localhost:9876/context.html'}, '', 'http://localhost:9876/context.html').once();
 
 		historyHandler.replaceInitialState(new CustomEvent('before', {detail: {options: {history: true}}}));
 
@@ -63,7 +63,7 @@ describe('HistoryHandler', function () {
 		naja.historyHandler.initialized = true;
 
 		const mock = sinon.mock(naja.historyHandler.historyAdapter);
-		mock.expects('pushState').withExactArgs({href: 'http://localhost:9876/HistoryHandler/pushState'}, '', 'http://localhost:9876/HistoryHandler/pushState').once();
+		mock.expects('pushState').withExactArgs({source: 'naja', href: 'http://localhost:9876/HistoryHandler/pushState'}, '', 'http://localhost:9876/HistoryHandler/pushState').once();
 
 		this.fetchMock.respond(200, {'Content-Type': 'application/json'}, {});
 		return naja.makeRequest('GET', '/HistoryHandler/pushState').then(() => {
@@ -81,7 +81,7 @@ describe('HistoryHandler', function () {
 		naja.historyHandler.initialized = true;
 
 		const mock = sinon.mock(naja.historyHandler.historyAdapter);
-		mock.expects('replaceState').withExactArgs({href: 'http://localhost:9876/HistoryHandler/replaceState'}, '', 'http://localhost:9876/HistoryHandler/replaceState').once();
+		mock.expects('replaceState').withExactArgs({source: 'naja', href: 'http://localhost:9876/HistoryHandler/replaceState'}, '', 'http://localhost:9876/HistoryHandler/replaceState').once();
 
 		this.fetchMock.respond(200, {'Content-Type': 'application/json'}, {});
 		return naja.makeRequest('GET', '/HistoryHandler/replaceState', null, {history: 'replace'}).then(() => {
@@ -99,7 +99,7 @@ describe('HistoryHandler', function () {
 		naja.historyHandler.initialized = true;
 
 		const mock = sinon.mock(naja.historyHandler.historyAdapter);
-		mock.expects('pushState').withExactArgs({href: '/HistoryHandler/postGet/targetUrl'}, '', '/HistoryHandler/postGet/targetUrl').once();
+		mock.expects('pushState').withExactArgs({source: 'naja', href: '/HistoryHandler/postGet/targetUrl'}, '', '/HistoryHandler/postGet/targetUrl').once();
 
 		this.fetchMock.respond(200, {'Content-Type': 'application/json'}, {url: '/HistoryHandler/postGet/targetUrl', postGet: true});
 		return naja.makeRequest('GET', '/HistoryHandler/postGet').then(() => {
@@ -256,7 +256,7 @@ describe('HistoryHandler', function () {
 			const restoreCallback = sinon.spy();
 			naja.historyHandler.addEventListener('restoreState', restoreCallback);
 
-			const state = {href: '/HistoryHandler/popState/event'};
+			const state = {source: 'naja', href: '/HistoryHandler/popState/event'};
 			window.dispatchEvent(createPopstateEvent(state));
 
 			assert.isTrue(restoreCallback.calledOnce);
@@ -282,6 +282,23 @@ describe('HistoryHandler', function () {
 			naja.historyHandler.addEventListener('restoreState', restoreCallback);
 
 			window.dispatchEvent(createPopstateEvent(null));
+
+			assert.isTrue(restoreCallback.notCalled);
+			cleanPopstateListener(naja.historyHandler);
+		});
+
+		it('does not dispatch event on foreign popstate', function () {
+			const naja = mockNaja({
+				snippetHandler: SnippetHandler,
+				historyHandler: HistoryHandler,
+			});
+			naja.historyHandler.initialize();
+
+			const restoreCallback = sinon.spy();
+			naja.historyHandler.addEventListener('restoreState', restoreCallback);
+
+			const state = {source: 'definitely-not-naja'};
+			window.dispatchEvent(createPopstateEvent(state));
 
 			assert.isTrue(restoreCallback.notCalled);
 			cleanPopstateListener(naja.historyHandler);

--- a/tests/Naja.SnippetCache.js
+++ b/tests/Naja.SnippetCache.js
@@ -279,7 +279,7 @@ describe('SnippetCache', function () {
 						.and(sinon.match.has('detail', sinon.match.object
 							.and(sinon.match.has('snippets', {'snippet-cache-foo': 'foo'}))
 							.and(sinon.match.has('state', {href: 'http://localhost:9876/SnippetCache/storeEvent', snippets: {storage: TEST_STORAGE_TYPE, key: 'key'}}))
-							.and(sinon.match.has('options', {snippetCache: TEST_STORAGE_TYPE, fetch: {}}))
+							.and(sinon.match.has('options', {snippetCache: TEST_STORAGE_TYPE, fetch: {}, href: 'http://localhost:9876/SnippetCache/storeEvent'}))
 						))
 				));
 

--- a/tests/Naja.SnippetCache.js
+++ b/tests/Naja.SnippetCache.js
@@ -39,8 +39,7 @@ describe('SnippetCache', function () {
 		const testStorage = new TestSnippetCacheStorage();
 		naja.snippetCache.storages[TEST_STORAGE_TYPE] = testStorage;
 
-		naja.initialize();
-		cleanPopstateListener(naja.historyHandler);
+		naja.historyHandler.initialized = true;
 
 		const historyAdapterMock = sinon.mock(naja.historyHandler.historyAdapter);
 		historyAdapterMock.expects('pushState').withExactArgs({
@@ -89,7 +88,7 @@ describe('SnippetCache', function () {
 		});
 		naja.snippetCache.storages[TEST_STORAGE_TYPE] = testStorage;
 
-		naja.initialize();
+		naja.historyHandler.initialize();
 
 		const el = document.createElement('div');
 		el.id = 'snippet-cache-foo';
@@ -260,8 +259,7 @@ describe('SnippetCache', function () {
 			const testStorage = new TestSnippetCacheStorage();
 			naja.snippetCache.storages[TEST_STORAGE_TYPE] = testStorage;
 
-			naja.initialize();
-			cleanPopstateListener(naja.historyHandler);
+			naja.historyHandler.initialized = true;
 			sinon.stub(naja.historyHandler.historyAdapter);
 
 			const el = document.createElement('div');
@@ -299,8 +297,7 @@ describe('SnippetCache', function () {
 			const testStorage = new TestSnippetCacheStorage();
 			naja.snippetCache.storages[TEST_STORAGE_TYPE] = testStorage;
 
-			naja.initialize();
-			cleanPopstateListener(naja.historyHandler);
+			naja.historyHandler.initialized = true;
 			sinon.stub(naja.historyHandler.historyAdapter);
 
 			const storeCallback = sinon.spy((evt) => evt.preventDefault());
@@ -325,7 +322,7 @@ describe('SnippetCache', function () {
 			});
 			naja.snippetCache.storages[TEST_STORAGE_TYPE] = testStorage;
 
-			naja.initialize();
+			naja.historyHandler.initialize();
 
 			const fetchCallback = sinon.spy();
 			const restoreCallback = sinon.spy();
@@ -380,7 +377,7 @@ describe('SnippetCache', function () {
 			});
 			naja.snippetCache.storages[TEST_STORAGE_TYPE] = testStorage;
 
-			naja.initialize();
+			naja.historyHandler.initialize();
 
 			const fetchCallback = sinon.spy((evt) => evt.preventDefault());
 			const restoreCallback = sinon.spy();
@@ -420,7 +417,7 @@ describe('SnippetCache', function () {
 			});
 			naja.snippetCache.storages[TEST_STORAGE_TYPE] = testStorage;
 
-			naja.initialize();
+			naja.historyHandler.initialize();
 
 			const restoreCallback = sinon.spy((evt) => evt.preventDefault());
 			naja.snippetCache.addEventListener('restore', restoreCallback);

--- a/tests/Naja.SnippetCache.js
+++ b/tests/Naja.SnippetCache.js
@@ -43,6 +43,7 @@ describe('SnippetCache', function () {
 
 		const historyAdapterMock = sinon.mock(naja.historyHandler.historyAdapter);
 		historyAdapterMock.expects('pushState').withExactArgs({
+			source: 'naja',
 			href: 'http://localhost:9876/SnippetCache/store',
 			snippets: {
 				storage: TEST_STORAGE_TYPE,
@@ -95,6 +96,7 @@ describe('SnippetCache', function () {
 		document.body.appendChild(el);
 
 		window.dispatchEvent(createPopstateEvent({
+			source: 'naja',
 			href: '/snippetCache/restore',
 			snippets: {
 				storage: TEST_STORAGE_TYPE,
@@ -276,7 +278,7 @@ describe('SnippetCache', function () {
 					sinon.match((event) => event.constructor.name === 'CustomEvent')
 						.and(sinon.match.has('detail', sinon.match.object
 							.and(sinon.match.has('snippets', {'snippet-cache-foo': 'foo'}))
-							.and(sinon.match.has('state', {href: 'http://localhost:9876/SnippetCache/storeEvent', snippets: {storage: TEST_STORAGE_TYPE, key: 'key'}}))
+							.and(sinon.match.has('state', {source: 'naja', href: 'http://localhost:9876/SnippetCache/storeEvent', snippets: {storage: TEST_STORAGE_TYPE, key: 'key'}}))
 							.and(sinon.match.has('options', {snippetCache: TEST_STORAGE_TYPE, fetch: {}, href: 'http://localhost:9876/SnippetCache/storeEvent'}))
 						))
 				));
@@ -334,6 +336,7 @@ describe('SnippetCache', function () {
 			document.body.appendChild(el);
 
 			const state = {
+				source: 'naja',
 				href: '/snippetCache/restoreEvents',
 				snippets: {
 					storage: TEST_STORAGE_TYPE,
@@ -389,6 +392,7 @@ describe('SnippetCache', function () {
 			document.body.appendChild(el);
 
 			const state = {
+				source: 'naja',
 				href: '/snippetCache/fetchEventCancel',
 				snippets: {
 					storage: TEST_STORAGE_TYPE,
@@ -427,6 +431,7 @@ describe('SnippetCache', function () {
 			document.body.appendChild(el);
 
 			const state = {
+				source: 'naja',
 				href: '/snippetCache/restoreEventCancel',
 				snippets: {
 					storage: TEST_STORAGE_TYPE,

--- a/tests/Naja.makeRequest.js
+++ b/tests/Naja.makeRequest.js
@@ -27,7 +27,7 @@ describe('makeRequest()', function () {
 		naja.addEventListener('complete', completeCallback);
 
 		this.fetchMock.respond(200, {'Content-Type': 'application/json'}, {answer: 42});
-		const request = naja.makeRequest('GET', '/makeRequest/success/events');
+		const request = naja.makeRequest('GET', '/makeRequest/success/events', null, {history: false});
 
 		return request.then(() => {
 			assert.isTrue(beforeCallback.called);
@@ -86,9 +86,10 @@ describe('makeRequest()', function () {
 	it('should resolve with the response if the request succeeds', function () {
 		const naja = mockNaja();
 		naja.initialize();
+		cleanPopstateListener(naja.historyHandler);
 
 		this.fetchMock.respond(200, {'Content-Type': 'application/json'}, {answer: 42});
-		const request = naja.makeRequest('GET', '/makeRequest/success/resolve');
+		const request = naja.makeRequest('GET', '/makeRequest/success/resolve', null, {history: false});
 
 		return request.then((response) => {
 			assert.deepEqual(response, {answer: 42});
@@ -113,7 +114,7 @@ describe('makeRequest()', function () {
 		naja.addEventListener('complete', completeCallback);
 
 		this.fetchMock.respond(500, {'Content-Type': 'application/json'}, {});
-		const request = naja.makeRequest('GET', '/makeRequest/error/events');
+		const request = naja.makeRequest('GET', '/makeRequest/error/events', null, {history: false});
 
 		return request.catch(() => {
 			assert.isTrue(beforeCallback.calledWith(
@@ -174,7 +175,7 @@ describe('makeRequest()', function () {
 		sinon.stub(naja.historyHandler.historyAdapter);
 
 		this.fetchMock.respond(500, {'Content-Type': 'application/json'}, {});
-		const request = naja.makeRequest('GET', '/makeRequest/error/reject');
+		const request = naja.makeRequest('GET', '/makeRequest/error/reject', null, {history: false});
 
 		return request.catch((error) => {
 			assert.isOk(error); // isOk = truthy
@@ -203,7 +204,7 @@ describe('makeRequest()', function () {
 		const error = new Error('NetworkError');
 		this.fetchMock.reject(error);
 
-		const request = naja.makeRequest('GET', '/makeRequest/error/events');
+		const request = naja.makeRequest('GET', '/makeRequest/error/events', null, {history: false});
 
 		return request.catch(() => {
 			assert.isTrue(beforeCallback.calledWith(
@@ -266,7 +267,7 @@ describe('makeRequest()', function () {
 		const error = new Error('NetworkError');
 		this.fetchMock.reject(error);
 
-		const request = naja.makeRequest('GET', '/makeRequest/error/reject');
+		const request = naja.makeRequest('GET', '/makeRequest/error/reject', null, {history: false});
 
 		return request.catch((actual) => {
 			assert.strictEqual(actual, error);
@@ -276,6 +277,7 @@ describe('makeRequest()', function () {
 	it('should call abort event if the request is aborted', function () {
 		const naja = mockNaja();
 		naja.initialize();
+		cleanPopstateListener(naja.historyHandler);
 
 		const abortCallback = sinon.spy();
 		const successCallback = sinon.spy();
@@ -287,7 +289,7 @@ describe('makeRequest()', function () {
 		naja.addEventListener('complete', completeCallback);
 
 		this.fetchMock.abort();
-		const request = naja.makeRequest('GET', '/makeRequest/abort');
+		const request = naja.makeRequest('GET', '/makeRequest/abort', null, {history: false});
 
 		return request.then((payload) => {
 			assert.deepEqual(payload, {});
@@ -328,7 +330,7 @@ describe('makeRequest()', function () {
 		naja.addEventListener('complete', completeCallback);
 		naja.addEventListener('before', (evt) => evt.preventDefault());
 
-		const request = naja.makeRequest('GET', '/makeRequest/abortedBefore');
+		const request = naja.makeRequest('GET', '/makeRequest/abortedBefore', null, {history: false});
 		return request.then((payload) => {
 			assert.deepEqual(payload, {});
 			assert.isFalse(completeCallback.called);
@@ -347,7 +349,7 @@ describe('makeRequest()', function () {
 		this.fetchMock.when((request) => request.url === 'http://localhost:9876/makeRequest/getFormData?foo=bar&baz=42')
 			.respond(200, {'Content-Type': 'application/json'}, {answer: 42});
 
-		const request = naja.makeRequest('GET', '/makeRequest/getFormData', formData);
+		const request = naja.makeRequest('GET', '/makeRequest/getFormData', formData, {history: false});
 		return request.then((payload) => {
 			assert.deepEqual(payload, {answer: 42});
 		});
@@ -375,7 +377,7 @@ describe('makeRequest()', function () {
 		this.fetchMock.when((request) => request.url === 'http://localhost:9876/makeRequest/getPOJO?foo=bar&baz=42&qux%5B0%5D%5Bbar%5D=baz&qux%5B0%5D%5Bbaz%5D=qux&qux%5B1%5D=foo')
 			.respond(200, {'Content-Type': 'application/json'}, {answer: 42});
 
-		const request = naja.makeRequest('GET', '/makeRequest/getPOJO', data);
+		const request = naja.makeRequest('GET', '/makeRequest/getPOJO', data, {history: false});
 		return request.then((payload) => {
 			assert.deepEqual(payload, {answer: 42});
 		});
@@ -406,7 +408,7 @@ describe('makeRequest()', function () {
 				{status: 200},
 			);
 
-		const request = naja.makeRequest('POST', '/makeRequest/postPOJO', data);
+		const request = naja.makeRequest('POST', '/makeRequest/postPOJO', data, {history: false});
 		return request.then((payload) => {
 			assert.deepEqual(payload, {request: 'foo=bar&baz=42&qux%5B0%5D%5Bbar%5D=baz&qux%5B0%5D%5Bbaz%5D=qux&qux%5B1%5D=foo'});
 		});
@@ -429,7 +431,7 @@ describe('makeRequest()', function () {
 				{status: 200},
 			);
 
-		const request = naja.makeRequest('POST', '/makeRequest/postArray', data);
+		const request = naja.makeRequest('POST', '/makeRequest/postArray', data, {history: false});
 		return request.then((payload) => {
 			assert.deepEqual(payload, {request: '0=42&1=foo&2=bar'});
 		});
@@ -445,7 +447,7 @@ describe('makeRequest()', function () {
 			naja.addEventListener('before', beforeCallback);
 
 			this.fetchMock.respond(200, {'Content-Type': 'application/json'}, {answer: 42});
-			const request = naja.makeRequest('GET', '/makeRequest/options/defaultOptions');
+			const request = naja.makeRequest('GET', '/makeRequest/options/defaultOptions', null, {history: false});
 
 			return request.then(() => {
 				assert.isTrue(beforeCallback.called);
@@ -471,7 +473,7 @@ describe('makeRequest()', function () {
 			};
 
 			this.fetchMock.respond(200, {'Content-Type': 'application/json'}, {answer: 42});
-			const request = naja.makeRequest('GET', '/makeRequest/options/defaultOptions', null, {'customOption': 24, 'anotherOption': 42});
+			const request = naja.makeRequest('GET', '/makeRequest/options/defaultOptions', null, {'customOption': 24, 'anotherOption': 42, history: false});
 
 			return request.then(() => {
 				assert.isTrue(beforeCallback.called);
@@ -494,7 +496,7 @@ describe('makeRequest()', function () {
 			this.fetchMock.when((request) => request.credentials === 'include')
 				.respond(200, {'Content-Type': 'application/json'}, {answer: 42});
 
-			return naja.makeRequest('GET', '/makeRequest/options/defaultOptions', null, {fetch: {credentials: 'include'}});
+			return naja.makeRequest('GET', '/makeRequest/options/defaultOptions', null, {fetch: {credentials: 'include'}, history: false});
 		});
 	});
 });


### PR DESCRIPTION
This is an alternative approach to #356 and implements the idea from there to only replace the initial state once a history-enabled request is dispatched through Naja. In addition, it explicitly marks the state produced by Naja, and fixes a potential race condition issue with concurrent requests.